### PR TITLE
Add context option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ argv.repo = argv.repo || process.env.GITHUB_REPO;
 argv.state = argv.state || process.env.GITHUB_STATE;
 argv['target-url'] = argv['target-url'] || process.env.GITHUB_TARGET_URL;
 argv.description = argv.description || process.env.GITHUB_DESCRIPTION;
+argv.context = argv.context || process.env.GITHUB_CONTEXT;
 
 var query;
 var StatusReporter = require('./lib');
@@ -18,7 +19,3 @@ statusReporter.update(argv, function (err, res) {
     console.log(res);
   }
 });
-
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,9 +105,9 @@ function postUpdates(github, argv, cb) {
     if (argv.description) {
       q.description = argv.description;
     }
+    if (argv.context) {
+      q.context = argv.context;
+    }
     github.statuses.create(q, cb);
   }
 }
-
-
-

--- a/readme.md
+++ b/readme.md
@@ -97,11 +97,14 @@ Optional message along with the status.
 
 `github-status-reporter --description 'tests failed' ...`
 
+###Context
+
+Optional string label to differentiate this status from the status of other systems. Can be set as an environment variable as GITHUB_CONTEXT.
+
+`github-status-reporter --context 'api' ...`
+
 ###Target-Url
 
 Optional link for when someone clicks on the build status.
 
 `github-status-reporter --target-url 'jenkins.example.com/build/1524' ...`
-
-
-


### PR DESCRIPTION
This adds the `context` option, as supported by GitHub and node-github.

GitHub API docs: https://developer.github.com/v3/repos/statuses/#create-a-status
node-github API docs: http://mikedeboer.github.io/node-github/#statuses

`context` is the bolded "continuous-integration..." text below:

![image](https://cloud.githubusercontent.com/assets/4616705/13310498/71de45c6-db54-11e5-910f-a9f08dabfa63.png)
